### PR TITLE
Add default constructor, remove unnecessary annotation

### DIFF
--- a/src/main/java/com/yourname/demo/SpringBootCourseApplication.java
+++ b/src/main/java/com/yourname/demo/SpringBootCourseApplication.java
@@ -7,6 +7,8 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 public class SpringBootCourseApplication {
 
 	public static void main(String[] args) {
+
 		SpringApplication.run(SpringBootCourseApplication.class, args);
+
 	}
 }

--- a/src/main/java/com/yourname/demo/model/Student.java
+++ b/src/main/java/com/yourname/demo/model/Student.java
@@ -6,17 +6,20 @@ import java.util.UUID;
 public class Student {
 
   private UUID id;
-  private final Integer age;
-  private final String firstName;
-  private final String lastName;
-  private final String course;
+  private Integer age;
+  private String firstName;
+  private String lastName;
+  private String course;
+
+  public Student(){
+  }
 
   public Student(
-      @JsonProperty("id") UUID id,
-      @JsonProperty("age") Integer age,
-      @JsonProperty("firstName") String firstName,
-      @JsonProperty("lastName") String lastName,
-      @JsonProperty("course") String course) {
+      UUID id,
+      Integer age,
+      String firstName,
+      String lastName,
+      String course) {
     this.id = id;
     this.age = age;
     this.firstName = firstName;

--- a/src/main/java/com/yourname/demo/service/StudentService.java
+++ b/src/main/java/com/yourname/demo/service/StudentService.java
@@ -14,7 +14,7 @@ public class StudentService {
   private final StudentDao studentDao;
 
   @Autowired
-  public StudentService(@Qualifier("mongoDbDao") StudentDao studentDao) {
+  public StudentService(@Qualifier("fakeDao") StudentDao studentDao) {
     this.studentDao = studentDao;
   }
 


### PR DESCRIPTION
If you create a default no-arg constructor and have your private variables editable you don't need the extra @JsonProperty annotations - which seem to be repetitive as they just state the variable name again (although if you needed to have the JSON coming in match a different name than the variable name you could use the @JsonProperty to map them). Just my 2 cents, but with a much larger model with way more properties adding that notation over and over again would be tedious.